### PR TITLE
Fix questionable onboard LED handling. Enforce/limit on/off time, extend to both SWD and UART read/write.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,16 +13,22 @@ add_executable(picoprobe
         src/probe.c
         src/cdc_uart.c
         src/get_serial.c
+        src/ws2812.c
 )
 
 if (DEFINED ENV{PICOPROBE_LED})
         message("PICOPROBE_LED is defined as " $ENV{PICOPROBE_LED})
         target_compile_definitions(picoprobe PRIVATE PICOPROBE_LED=$ENV{PICOPROBE_LED})
 endif()
+if (DEFINED ENV{PICOPROBE_WS2812})
+        message("PICOPROBE_WS2812 is defined as " $ENV{PICOPROBE_WS2812})
+        target_compile_definitions(picoprobe PRIVATE PICOPROBE_WS2812=$ENV{PICOPROBE_WS2812})
+endif()
 
 set(DBG_PIN_COUNT=4)
 
 pico_generate_pio_header(picoprobe ${CMAKE_CURRENT_LIST_DIR}/src/probe.pio)
+pico_generate_pio_header(picoprobe ${CMAKE_CURRENT_LIST_DIR}/src/ws2812.pio)
 
 target_include_directories(picoprobe PRIVATE src)
 

--- a/src/cdc_uart.c
+++ b/src/cdc_uart.c
@@ -27,6 +27,7 @@
 
 #include "tusb.h"
 
+#include "led.h"
 #include "picoprobe_config.h"
 
 void cdc_uart_init(void) {
@@ -49,6 +50,9 @@ void cdc_task(void) {
     if (tud_cdc_connected()) {
         // Do we have anything to display on the host's terminal?
         if (rx_len) {
+#ifdef NEWLED
+            led_signal_write_uart(rx_len);
+#endif
             for (uint i = 0; i < rx_len; i++) {
                 tud_cdc_write_char(rx_buf[i]);
             }
@@ -58,6 +62,9 @@ void cdc_task(void) {
         if (tud_cdc_available()) {
             // Is there any data from the host for us to tx
             uint tx_len = tud_cdc_read(tx_buf, sizeof(tx_buf));
+#ifdef NEWLED
+            led_signal_read_uart(tx_len);
+#endif
             uart_write_blocking(PICOPROBE_UART_INTERFACE, tx_buf, tx_len);
         }
     }

--- a/src/led.c
+++ b/src/led.c
@@ -34,28 +34,53 @@
 static uint32_t led_count;
 
 void led_init(void) {
-    led_count = 0;
+    led_count = 0xffff; // We can watch this being counted down towards zero with a 'scope
 
     gpio_init(PICOPROBE_LED);
     gpio_set_dir(PICOPROBE_LED, GPIO_OUT);
     gpio_put(PICOPROBE_LED, 1);
+    gpio_put(PICOPROBE_LED, 0); // Recognisable timing datum
+    gpio_put(PICOPROBE_LED, 1); // Start of 64K countdown
 }
 
+/*
+ * Timing on a Waveshare RP2040-Zero is 65535 counting down to zero = approx
+ * 150 mSec. So if a signal (SWD write etc.) triggers the start, a preload of
+ * 64K would cap repetition to roughly that rate, and turning off the LED at
+ * 32K would give an "on" time of roughly 75 mSec which is compatible with
+ * industry usage. 
+*/
 
 
 void led_task(void) {
     if (led_count != 0) {
-        --led_count;
-        gpio_put(PICOPROBE_LED, !((led_count >> LED_COUNT_SHIFT) & 1));
+        led_count -= 1;
+        if (led_count == 32767)
+            gpio_put(PICOPROBE_LED, 0);
     }
 }
 
 void led_signal_activity(uint total_bits) {
     if (led_count == 0) {
-        gpio_put(PICOPROBE_LED, 0);
-    }
-
-    if (led_count < LED_COUNT_MAX) {
-        led_count += total_bits;
+        led_count = 65535;
+        gpio_put(PICOPROBE_LED, 1);
     }
 }
+
+
+void led_signal_write_swd(uint total_bits) {
+    led_signal_activity(total_bits);
+}
+
+void led_signal_read_swd(uint total_bits) {
+    led_signal_activity(total_bits);
+}
+
+void led_signal_write_uart(uint total_bytes) {
+    led_signal_activity(total_bytes << 3);
+}
+
+void led_signal_read_uart(uint total_bytes) {
+    led_signal_activity(total_bytes << 3);
+}
+

--- a/src/led.h
+++ b/src/led.h
@@ -26,8 +26,19 @@
 #ifndef LED_H
 #define LED_H
 
+#define NEWLED 1
+
 void led_init(void);
 void led_task(void);
+
+#ifndef NEWLED
 void led_signal_activity(uint total_bits);
+#else
+void led_signal_write_swd(uint total_bits);
+void led_signal_read_swd(uint total_bits);
+void led_signal_write_uart(uint total_bytes);
+void led_signal_read_uart(uint total_bytes);
+#endif
 
 #endif
+

--- a/src/main.c
+++ b/src/main.c
@@ -46,9 +46,21 @@ int main(void) {
     cdc_uart_init();
     tusb_init();
     probe_init();
-    led_init();
+    led_init(); 
 
-    picoprobe_info("Welcome to Picoprobe!\n");
+/*
+ * Keep led_init() at the end, so that the time it takes to count an initial
+ * value down to zero can be checked with a 'scope or logic analyser.
+ */
+
+    picoprobe_info("Welcome to Picoprobe! ");
+#ifdef PROBE_PIN_RESET
+    picoprobe_info("Reset: GP%d ", PROBE_PIN_RESET);
+#endif
+#ifdef PICOPROBE_LED
+    picoprobe_info("LED: GP%d", PICOPROBE_LED);
+#endif
+    picoprobe_info("\n");
 
     while (1) {
         tud_task(); // tinyusb device task

--- a/src/picoprobe_config.h
+++ b/src/picoprobe_config.h
@@ -32,7 +32,6 @@
 #define picoprobe_info(format,...) ((void)0)
 #endif
 
-
 #if false
 #define picoprobe_debug(format,args...) printf(format, ## args)
 #else
@@ -44,7 +43,6 @@
 #else
 #define picoprobe_dump(format,...) ((void)0)
 #endif
-
 
 // PIO config
 #define PROBE_SM 0
@@ -62,16 +60,53 @@
 #define PICOPROBE_UART_BAUDRATE 115200
 
 // LED config
-#ifndef PICOPROBE_LED
-
-#ifndef PICO_DEFAULT_LED_PIN
-#error PICO_DEFAULT_LED_PIN is not defined, run PICOPROBE_LED=<led_pin> cmake
-#elif PICO_DEFAULT_LED_PIN == -1
-#error PICO_DEFAULT_LED_PIN is defined as -1, run PICOPROBE_LED=<led_pin> cmake
+#ifdef PICOPROBE_LED
+  #define HAS_FLASHER 1
 #else
-#define PICOPROBE_LED PICO_DEFAULT_LED_PIN
+  #if PICO_DEFAULT_LED_PIN == -1
+    #undef PICO_DEFAULT_LED_PIN
+  #endif
+  #ifdef PICO_DEFAULT_LED_PIN
+    #define PICOPROBE_LED PICO_DEFAULT_LED_PIN
+    #define HAS_FLASHER 1
+  #endif
 #endif
+
+// WS2812 confid
+#ifdef PICOPROBE_WS2812
+  #define HAS_FLASHER 1
+#else
+  #if PICO_DEFAULT_WS2812_PIN == -1
+    #undef PICO_DEFAULT_WS2812_PIN
+  #endif
+  #ifdef PICO_DEFAULT_WS2812_PIN
+    #define PICOPROBE_WS2812 PICO_DEFAULT_WS2812_PIN
+    #define HAS_FLASHER 1
+  #endif
+#endif
+
+#ifndef HAS_FLASHER
+  #warning PICO_DEFAULT_LED_PIN is undefined or defined as -1, run PICOPROBE_LED=<led_pin> cmake
+  #warning PICO_DEFAULT_WS2812_PIN is undefined or defined as -1, run PICOPROBE_WS2812=<ws2812_pin> cmake
+  #error Either or both of PICOPROBE_LED or PICOPROBE_WS2812 must be defined, or have sensible defaults from the board definition.
+#endif
+
+// Keep the colours no brighter than necessary to avoid overloading the grain-
+// of-rice voltage regulator since this is also supplying the target board.
+
+#define COLOUR_RED     0x040000
+#define COLOUR_GREEN   0x000300
+#define COLOUR_BLUE    0x000004
+#define COLOUR_CYAN    0x000102
+#define COLOUR_MAGENTA 0x020002
+#define COLOUR_YELLOW  0x020100
+#define COLOUR_WHITE   0x010102
+#define COLOUR_BLACK   0x000000
+
+#define COLOUR_SWD_W   COLOUR_GREEN
+#define COLOUR_SWD_R   COLOUR_MAGENTA
+#define COLOUR_UART_W  COLOUR_YELLOW
+#define COLOUR_UART_R  COLOUR_BLUE
 
 #endif
 
-#endif

--- a/src/probe.c
+++ b/src/probe.c
@@ -216,7 +216,7 @@ void probe_handle_write(uint8_t *data, uint total_bits) {
     picoprobe_debug("Write %d bits\n", total_bits);
 
 #ifndef NEWLED
-    led_signal_activity(total_bits);
+    led_signal_activity(total_bits, 1);
 #else
     if (total_bits >= 33)
         led_signal_write_swd(total_bits);

--- a/src/ws2812.h
+++ b/src/ws2812.h
@@ -2,6 +2,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2021 a-pushkin on GitHub
+ * Copyright (c) 2021 a-smittytone on GitHub
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,22 +24,10 @@
  *
  */
 
-#ifndef LED_H
-#define LED_H
+#ifndef WS2812_H
+#define WS2812_H
 
-#define NEWLED 1
-
-void led_init(void);
-void led_task(void);
-
-#ifndef NEWLED
-void led_signal_activity(uint total_bits, uint32_t colour);
-#else
-void led_signal_write_swd(uint total_bits);
-void led_signal_read_swd(uint total_bits);
-void led_signal_write_uart(uint total_bytes);
-void led_signal_read_uart(uint total_bytes);
-#endif
+void ws2812_init(void);
+void put_pixel(uint32_t colour);
 
 #endif
-

--- a/src/ws2812.pio
+++ b/src/ws2812.pio
@@ -1,0 +1,85 @@
+;
+; Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+;
+; SPDX-License-Identifier: BSD-3-Clause
+;
+
+.program ws2812
+.side_set 1
+
+.define public T1 2
+.define public T2 5
+.define public T3 3
+
+.lang_opt python sideset_init = pico.PIO.OUT_HIGH
+.lang_opt python out_init     = pico.PIO.OUT_HIGH
+.lang_opt python out_shiftdir = 1
+
+.wrap_target
+bitloop:
+    out x, 1       side 0 [T3 - 1] ; Side-set still takes place when instruction stalls
+    jmp !x do_zero side 1 [T1 - 1] ; Branch on the bit we shifted out. Positive pulse
+do_one:
+    jmp  bitloop   side 1 [T2 - 1] ; Continue driving high, for a long pulse
+do_zero:
+    nop            side 0 [T2 - 1] ; Or drive low, for a short pulse
+.wrap
+
+% c-sdk {
+#include "hardware/clocks.h"
+
+static inline void ws2812_program_init(PIO pio, uint sm, uint offset, uint pin, float freq, bool rgbw) {
+
+    pio_gpio_init(pio, pin);
+    pio_sm_set_consecutive_pindirs(pio, sm, pin, 1, true);
+
+    pio_sm_config c = ws2812_program_get_default_config(offset);
+    sm_config_set_sideset_pins(&c, pin);
+    sm_config_set_out_shift(&c, false, true, rgbw ? 32 : 24);
+    sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_TX);
+
+    int cycles_per_bit = ws2812_T1 + ws2812_T2 + ws2812_T3;
+    float div = clock_get_hz(clk_sys) / (freq * cycles_per_bit);
+    sm_config_set_clkdiv(&c, div);
+
+    pio_sm_init(pio, sm, offset, &c);
+    pio_sm_set_enabled(pio, sm, true);
+}
+%}
+
+.program ws2812_parallel
+
+.define public T1 2
+.define public T2 5
+.define public T3 3
+
+.wrap_target
+    out x, 32
+    mov pins, !null [T1-1]
+    mov pins, x     [T2-1]
+    mov pins, null  [T3-2]
+.wrap
+
+% c-sdk {
+#include "hardware/clocks.h"
+
+static inline void ws2812_parallel_program_init(PIO pio, uint sm, uint offset, uint pin_base, uint pin_count, float freq) {
+    for(uint i=pin_base; i<pin_base+pin_count; i++) {
+        pio_gpio_init(pio, i);
+    }
+    pio_sm_set_consecutive_pindirs(pio, sm, pin_base, pin_count, true);
+
+    pio_sm_config c = ws2812_parallel_program_get_default_config(offset);
+    sm_config_set_out_shift(&c, true, true, 32);
+    sm_config_set_out_pins(&c, pin_base, pin_count);
+    sm_config_set_set_pins(&c, pin_base, pin_count);
+    sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_TX);
+
+    int cycles_per_bit = ws2812_parallel_T1 + ws2812_parallel_T2 + ws2812_parallel_T3;
+    float div = clock_get_hz(clk_sys) / (freq * cycles_per_bit);
+    sm_config_set_clkdiv(&c, div);
+
+    pio_sm_init(pio, sm, offset, &c);
+    pio_sm_set_enabled(pio, sm, true);
+}
+%}


### PR DESCRIPTION
Fix questionable onboard LED handling. Enforce/limit on/off time, extend to both SWD and UART read/write.

Tested with LED on GP7 on a Waveshare RP2040-Zero.

This would benefit from attention from an expert to ensure that the LED is not triggered by the constant flow of SWD packets when OpenOCD is in the quiescent state.

The main project could usefully document that the Picoprobe's GP6 is reserved as a reset signal.
