### PR TITLE
Add pin names to binary information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(debugprobe)
 pico_sdk_init()
 
 add_executable(debugprobe
+        src/probe_config.c
         src/led.c
         src/main.c
         src/usb_descriptors.c

--- a/include/board_example_config.h
+++ b/include/board_example_config.h
@@ -60,7 +60,7 @@
 #endif
 
 /* PIO config for PROBE_IO_OEN - note that SWDIOEN and SWCLK are both side_set signals, so must be consecutive. */
-#if defined(PROBE_IO_SWDIOEN)
+#if defined(PROBE_IO_OEN)
 #define PROBE_PIN_SWDIOEN (PROBE_PIN_OFFSET + 0)
 #define PROBE_PIN_SWCLK (PROBE_PIN_OFFSET + 1)
 #define PROBE_PIN_SWDIO (PROBE_PIN_OFFSET + 2)

--- a/src/main.c
+++ b/src/main.c
@@ -80,6 +80,8 @@ void usb_thread(void *ptr)
 #endif
 
 int main(void) {
+    // Declare pins in binary information
+    bi_decl_config();
 
     board_init();
     usb_serial_init();

--- a/src/probe_config.c
+++ b/src/probe_config.c
@@ -1,0 +1,48 @@
+#include "probe_config.h"
+#include "pico/binary_info.h"
+
+
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+
+void bi_decl_config()
+{
+#ifdef PROBE_PIN_RESET
+    bi_decl(bi_1pin_with_name(PROBE_PIN_RESET, "PROBE RESET"));
+#endif
+
+#ifdef PROBE_PIN_SWCLK
+    bi_decl(bi_1pin_with_name(PROBE_PIN_SWCLK, "PROBE SWCLK"));
+#endif
+
+#ifdef PROBE_PIN_SWDIO
+    bi_decl(bi_1pin_with_name(PROBE_PIN_SWDIO, "PROBE SWDIO"));
+#endif
+
+#ifdef PROBE_PIN_SWDI
+    bi_decl(bi_1pin_with_name(PROBE_PIN_SWDI, "PROBE SWDI"));
+#endif
+
+#ifdef PROBE_PIN_SWDIOEN
+    bi_decl(bi_1pin_with_name(PROBE_PIN_SWDIOEN, "PROBE SWDIOEN"));
+#endif
+
+#ifdef PROBE_CDC_UART
+    bi_decl(bi_program_feature("PROBE UART INTERFACE " STR(PROBE_UART_INTERFACE)));
+    bi_decl(bi_program_feature("PROBE UART BAUDRATE " STR(PROBE_UART_BAUDRATE)));
+    bi_decl(bi_1pin_with_name(PROBE_UART_TX, "PROBE UART TX"));
+    bi_decl(bi_1pin_with_name(PROBE_UART_RX, "PROBE UART RX"));
+#endif
+
+#ifdef PROBE_UART_CTS
+    bi_decl(bi_1pin_with_name(PROBE_UART_CTS, "PROBE UART CTS"));
+#endif
+#ifdef PROBE_UART_RTS
+    bi_decl(bi_1pin_with_name(PROBE_UART_RTS, "PROBE UART RTS"));
+#endif
+#ifdef PROBE_UART_DTR
+    bi_decl(bi_1pin_with_name(PROBE_UART_DTR, "PROBE UART DTR"));
+#endif
+
+}

--- a/src/probe_config.h
+++ b/src/probe_config.h
@@ -72,6 +72,8 @@ do { \
 #endif
 //#include "board_example_config.h"
 
+// Add the configuration to binary information
+void bi_decl_config();
 
 #define PROTO_DAP_V1 1
 #define PROTO_DAP_V2 2


### PR DESCRIPTION
I added the pin names to the binary information in case someone downloaded the firmware ten years ago and forget which pins to use. 
