### PR TITLE
Make target reset functionality work out-of-the-box

### DIFF
--- a/include/board_pico_config.h
+++ b/include/board_pico_config.h
@@ -40,8 +40,8 @@
 #endif
 
 // UART config
-#define PROBE_UART_TX 8
-#define PROBE_UART_RX 9
+#define PROBE_UART_TX 4
+#define PROBE_UART_RX 5
 #define PROBE_UART_INTERFACE uart1
 #define PROBE_UART_BAUDRATE 115200
 

--- a/include/board_pico_config.h
+++ b/include/board_pico_config.h
@@ -36,7 +36,7 @@
 #define PROBE_PIN_SWDIO (PROBE_PIN_OFFSET + 1) // 3
 // Target reset config
 #if false
-#define PROBE_PIN_RESET (PROBE_PIN_OFFSET + 2) // 4
+#define PROBE_PIN_RESET 1
 #endif
 
 // UART config

--- a/include/board_pico_config.h
+++ b/include/board_pico_config.h
@@ -36,12 +36,12 @@
 #define PROBE_PIN_SWDIO (PROBE_PIN_OFFSET + 1) // 3
 // Target reset config
 #if false
-#define PROBE_PIN_RESET 1
+#define PROBE_PIN_RESET (PROBE_PIN_OFFSET + 2) // 4
 #endif
 
 // UART config
-#define PROBE_UART_TX 4
-#define PROBE_UART_RX 5
+#define PROBE_UART_TX 8
+#define PROBE_UART_RX 9
 #define PROBE_UART_INTERFACE uart1
 #define PROBE_UART_BAUDRATE 115200
 

--- a/src/main.c
+++ b/src/main.c
@@ -85,9 +85,9 @@ int main(void) {
     usb_serial_init();
     cdc_uart_init();
     tusb_init();
+    stdio_uart_init();
 
     DAP_Setup();
-    stdio_uart_init();
 
     led_init();
 

--- a/src/probe.c
+++ b/src/probe.c
@@ -72,7 +72,7 @@ void probe_assert_reset(bool state)
 {
 #if defined(PROBE_PIN_RESET)
     /* Change the direction to out to drive pin to 0 or to in to emulate open drain */
-    gpio_set_dir(PROBE_PIN_RESET, state);
+    gpio_set_dir(PROBE_PIN_RESET, state == 0 ? GPIO_OUT : GPIO_IN);
 #endif
 }
 
@@ -170,6 +170,9 @@ void probe_deinit(void)
     probe_read_mode();
     pio_sm_set_enabled(pio0, PROBE_SM, 0);
     pio_remove_program(pio0, &probe_program, probe.offset);
+
+    probe_assert_reset(1);	// de-assert nRESET
+
     probe.initted = 0;
   }
 }


### PR DESCRIPTION
There are multiple problems that prevent target reset functionality from working properly:

1. GP1 doesn't seem to work, haven't really dug into why. 
   Moving to GP4 works, but this also means having to shift the UART to GP8/9.

2. `gpio_set_dir()` for the reset pin is opposite to what was intended:
   `state = 0` means assert reset, but the current logic in `probe_assert_reset` passes `state` directly to `gpio_set_dir`, which when `0` actually means `GPIO_IN`. When the pin is an input state, it is pulled-up high, so reset is actually _not assserted_.

3. Reset pin also needs to be de-asserted in `probe_deinit`.
   Otherwise when a connection is first attempted and failed, nRESET will be stuck in an asserted state subsequently.

With multiple issues stacked together, target reset functionality could not be enabled easily by tweaking some `#defines`,
as evidenced by issue #120.

This PR should make target reset work properly now.
