### PR TITLE
Add version to binary info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,18 @@ pico_generate_pio_header(debugprobe ${CMAKE_CURRENT_LIST_DIR}/src/probe_oen.pio)
 
 target_include_directories(debugprobe PRIVATE src)
 
+# add version
+add_custom_target(version
+        ${CMAKE_SOURCE_DIR}/get-version.sh
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+target_include_directories(debugprobe PRIVATE
+        ${CMAKE_BINARY_DIR}/generated
+        )
+
+add_dependencies(debugprobe version)
+
 target_compile_definitions (debugprobe PRIVATE
 	PICO_RP2040_USB_DEVICE_ENUMERATION_FIX=1
 )

--- a/get-version.sh
+++ b/get-version.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+if command -v git &>/dev/null
+then
+    VERSION=$(git describe --exact-match --tags 2> /dev/null || git rev-parse --short HEAD)   
+else
+    VERSION="unknown"
+fi
+
+if [ ! -e generated/probe ]
+then
+    mkdir -p generated/probe
+fi
+
+cat > generated/probe/version.h << EOF
+#ifndef _PROBE_VERSION_H
+#define _PROBE_VERSION_H
+
+#define PROBE_VERSION "${VERSION}"
+
+#endif
+EOF

--- a/src/probe_config.c
+++ b/src/probe_config.c
@@ -1,6 +1,6 @@
 #include "probe_config.h"
 #include "pico/binary_info.h"
-
+#include "probe/version.h"
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
@@ -8,6 +8,7 @@
 
 void bi_decl_config()
 {
+    bi_decl(bi_program_version_string(PROBE_VERSION));
 #ifdef PROBE_PIN_RESET
     bi_decl(bi_1pin_with_name(PROBE_PIN_RESET, "PROBE RESET"));
 #endif


### PR DESCRIPTION
As suggested in #132, I added the version to binary by telling it from git. If git HEAD is tagged, then the tag is used as version; otherwise, the short commit hash is used. What else should be added? 
