### PR TITLE
Output control on debug clock and data lines

### DIFF
--- a/src/probe.c
+++ b/src/probe.c
@@ -36,6 +36,7 @@
 #include "tusb.h"
 
 #define PADS_BANK0_GPIO12       _u(12)
+#define PADS_BANK0_GPIO14       _u(14)
 
 #define DIV_ROUND_UP(m, n)	(((m) + (n) - 1) / (n))
 
@@ -150,6 +151,7 @@ void probe_write_mode(void) {
 void probe_init() {
     if (!probe.initted) {
         hw_clear_bits(&padsbank0_hw->io[PADS_BANK0_GPIO12], PADS_BANK0_GPIO12_OD_BITS);
+        hw_clear_bits(&padsbank0_hw->io[PADS_BANK0_GPIO14], PADS_BANK0_GPIO14_OD_BITS);
         uint offset = pio_add_program(pio0, &probe_program);
         probe.offset = offset;
 
@@ -179,5 +181,6 @@ void probe_deinit(void)
     probe.initted = 0;
       
     hw_set_bits(&padsbank0_hw->io[PADS_BANK0_GPIO12], PADS_BANK0_GPIO12_OD_BITS);
+    hw_set_bits(&padsbank0_hw->io[PADS_BANK0_GPIO14], PADS_BANK0_GPIO14_OD_BITS);
   }
 }

--- a/src/probe.c
+++ b/src/probe.c
@@ -35,9 +35,6 @@
 #include "probe.pio.h"
 #include "tusb.h"
 
-#define PADS_BANK0_GPIO12       _u(12)
-#define PADS_BANK0_GPIO14       _u(14)
-
 #define DIV_ROUND_UP(m, n)	(((m) + (n) - 1) / (n))
 
 // Only want to set / clear one gpio per event so go up in powers of 2
@@ -150,8 +147,8 @@ void probe_write_mode(void) {
 
 void probe_init() {
     if (!probe.initted) {
-        hw_clear_bits(&padsbank0_hw->io[PADS_BANK0_GPIO12], PADS_BANK0_GPIO12_OD_BITS);
-        hw_clear_bits(&padsbank0_hw->io[PADS_BANK0_GPIO14], PADS_BANK0_GPIO14_OD_BITS);
+        hw_clear_bits(&padsbank0_hw->io[PROBE_PIN_SWCLK], PADS_BANK0_GPIO12_OD_BITS);
+        hw_clear_bits(&padsbank0_hw->io[PROBE_PIN_SWDIO], PADS_BANK0_GPIO14_OD_BITS);
         uint offset = pio_add_program(pio0, &probe_program);
         probe.offset = offset;
 
@@ -180,7 +177,7 @@ void probe_deinit(void)
 
     probe.initted = 0;
       
-    hw_set_bits(&padsbank0_hw->io[PADS_BANK0_GPIO12], PADS_BANK0_GPIO12_OD_BITS);
-    hw_set_bits(&padsbank0_hw->io[PADS_BANK0_GPIO14], PADS_BANK0_GPIO14_OD_BITS);
+    hw_set_bits(&padsbank0_hw->io[PROBE_PIN_SWCLK], PADS_BANK0_GPIO12_OD_BITS);
+    hw_set_bits(&padsbank0_hw->io[PROBE_PIN_SWDIO], PADS_BANK0_GPIO14_OD_BITS);
   }
 }

--- a/src/probe.c
+++ b/src/probe.c
@@ -35,6 +35,8 @@
 #include "probe.pio.h"
 #include "tusb.h"
 
+#define PADS_BANK0_GPIO12       _u(12)
+
 #define DIV_ROUND_UP(m, n)	(((m) + (n) - 1) / (n))
 
 // Only want to set / clear one gpio per event so go up in powers of 2
@@ -147,6 +149,7 @@ void probe_write_mode(void) {
 
 void probe_init() {
     if (!probe.initted) {
+        hw_clear_bits(&padsbank0_hw->io[PADS_BANK0_GPIO12], PADS_BANK0_GPIO12_OD_BITS);
         uint offset = pio_add_program(pio0, &probe_program);
         probe.offset = offset;
 
@@ -174,5 +177,7 @@ void probe_deinit(void)
     probe_assert_reset(1);	// de-assert nRESET
 
     probe.initted = 0;
+      
+    hw_set_bits(&padsbank0_hw->io[PADS_BANK0_GPIO12], PADS_BANK0_GPIO12_OD_BITS);
   }
 }

--- a/src/probe.c
+++ b/src/probe.c
@@ -150,8 +150,8 @@ void probe_write_mode(void) {
 
 void probe_init() {
     if (!probe.initted) {
-        hw_clear_bits(&padsbank0_hw->io[PROBE_PIN_SWCLK], PADS_BANK0_GPIO12_OD_BITS);
-        hw_clear_bits(&padsbank0_hw->io[PROBE_PIN_SWDIO], PADS_BANK0_GPIO14_OD_BITS);
+        hw_clear_bits(&padsbank0_hw->io[PROBE_PIN_SWCLK], PADS_BANK0_GPIO_OD_BITS);
+        hw_clear_bits(&padsbank0_hw->io[PROBE_PIN_SWDIO], PADS_BANK0_GPIO_OD_BITS);
         
         uint offset = pio_add_program(pio0, &probe_program);
         probe.offset = offset;

--- a/src/probe.c
+++ b/src/probe.c
@@ -35,6 +35,9 @@
 #include "probe.pio.h"
 #include "tusb.h"
 
+// Generic definition for OD bits since all GPIOs define it the same
+#define PADS_BANK0_GPIO_OD_BITS    _u(0x00000080)
+
 #define DIV_ROUND_UP(m, n)	(((m) + (n) - 1) / (n))
 
 // Only want to set / clear one gpio per event so go up in powers of 2
@@ -149,6 +152,7 @@ void probe_init() {
     if (!probe.initted) {
         hw_clear_bits(&padsbank0_hw->io[PROBE_PIN_SWCLK], PADS_BANK0_GPIO12_OD_BITS);
         hw_clear_bits(&padsbank0_hw->io[PROBE_PIN_SWDIO], PADS_BANK0_GPIO14_OD_BITS);
+        
         uint offset = pio_add_program(pio0, &probe_program);
         probe.offset = offset;
 
@@ -177,7 +181,7 @@ void probe_deinit(void)
 
     probe.initted = 0;
       
-    hw_set_bits(&padsbank0_hw->io[PROBE_PIN_SWCLK], PADS_BANK0_GPIO12_OD_BITS);
-    hw_set_bits(&padsbank0_hw->io[PROBE_PIN_SWDIO], PADS_BANK0_GPIO14_OD_BITS);
+    hw_set_bits(&padsbank0_hw->io[PROBE_PIN_SWCLK], PADS_BANK0_GPIO_OD_BITS);
+    hw_set_bits(&padsbank0_hw->io[PROBE_PIN_SWDIO], PADS_BANK0_GPIO_OD_BITS);
   }
 }


### PR DESCRIPTION
The current release of the firmware leaves the clock and data lines with output enabled after deinit. When the probe is used as a component of a larger system/project, this can lead to unintended side effects such as interference with other communications (as the probe may still be trying to communicate), unintended operations, or signal interference.

Solution:
- In probe_deinit(), disable output on the clock and data lines
- In probe_init(), enable output on the clock and data lines

Note: this solution avoids needing to modify the PIO state machine implementation which is why I took this (much easier) route