### PR TITLE
Debugprobe release v2.2.2

### DIFF
--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -48,7 +48,7 @@ tusb_desc_device_t const desc_device =
 
     .idVendor           = 0x2E8A, // Pi
     .idProduct          = 0x000c, // CMSIS-DAP Debug Probe
-    .bcdDevice          = 0x0221, // Version 02.21
+    .bcdDevice          = 0x0222, // Version 02.22
     .iManufacturer      = 0x01,
     .iProduct           = 0x02,
     .iSerialNumber      = 0x03,


### PR DESCRIPTION
Point release to address high uart TX baud rate corruption, at the expense of throughput.

Also skip over an attempt at UART/SDK optimisation that caused issues for users.