### PR TITLE
Add USB reset interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ target_include_directories(debugprobe PRIVATE src)
 
 target_compile_definitions (debugprobe PRIVATE
 	PICO_RP2040_USB_DEVICE_ENUMERATION_FIX=1
+    PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE=1
 )
 
 option (DEBUG_ON_PICO "Compile firmware for the Pico instead of Debug Probe" OFF)
@@ -71,6 +72,7 @@ endif ()
 target_link_libraries(debugprobe PRIVATE
         pico_multicore
         pico_stdlib
+        pico_usb_reset_interface
         pico_unique_id
         tinyusb_device
         tinyusb_board

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ target_include_directories(debugprobe PRIVATE src)
 
 target_compile_definitions (debugprobe PRIVATE
 	PICO_RP2040_USB_DEVICE_ENUMERATION_FIX=1
-    PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE=1
+    PICO_ENABLE_USB_RESET_VIA_VENDOR_INTERFACE=1
 )
 
 option (DEBUG_ON_PICO "Compile firmware for the Pico instead of Debug Probe" OFF)
@@ -72,7 +72,7 @@ endif ()
 target_link_libraries(debugprobe PRIVATE
         pico_multicore
         pico_stdlib
-        pico_usb_reset_interface
+        pico_usb_reset
         pico_unique_id
         tinyusb_device
         tinyusb_board

--- a/src/tusb_edpt_handler.c
+++ b/src/tusb_edpt_handler.c
@@ -282,10 +282,15 @@ usbd_class_driver_t const _dap_edpt_driver =
 #endif
 };
 
+static usbd_class_driver_t const _edpt_drivers[] = {
+	_dap_edpt_driver,
+	_resetd_driver,
+};
+
 // Add the custom driver to the tinyUSB stack
 usbd_class_driver_t const *usbd_app_driver_get_cb(uint8_t *driver_count)
 {
-	*driver_count = 1;
-	return &_dap_edpt_driver;
+	*driver_count = sizeof(_edpt_drivers) / sizeof(_edpt_drivers[0]);
+	return _edpt_drivers;
 }
 

--- a/src/tusb_edpt_handler.c
+++ b/src/tusb_edpt_handler.c
@@ -284,7 +284,7 @@ usbd_class_driver_t const _dap_edpt_driver =
 
 static usbd_class_driver_t const _edpt_drivers[] = {
 	_dap_edpt_driver,
-	_resetd_driver,
+	pico_usb_reset_interface_driver,
 };
 
 // Add the custom driver to the tinyUSB stack

--- a/src/tusb_edpt_handler.c
+++ b/src/tusb_edpt_handler.c
@@ -284,7 +284,7 @@ usbd_class_driver_t const _dap_edpt_driver =
 
 static usbd_class_driver_t const _edpt_drivers[] = {
 	_dap_edpt_driver,
-	pico_usb_reset_interface_driver,
+	usb_reset_interface_driver,
 };
 
 // Add the custom driver to the tinyUSB stack

--- a/src/tusb_edpt_handler.h
+++ b/src/tusb_edpt_handler.h
@@ -12,6 +12,8 @@
 #include "device/usbd_pvt.h"
 #include "DAP_config.h"
 
+#include "pico/usb_reset_interface.h"
+
 #define DAP_INTERFACE_SUBCLASS 0x00
 #define DAP_INTERFACE_PROTOCOL 0x00
 

--- a/src/tusb_edpt_handler.h
+++ b/src/tusb_edpt_handler.h
@@ -12,7 +12,7 @@
 #include "device/usbd_pvt.h"
 #include "DAP_config.h"
 
-#include "pico/usb_reset_interface.h"
+#include "pico/usb_reset_interface_device.h"
 
 #define DAP_INTERFACE_SUBCLASS 0x00
 #define DAP_INTERFACE_PROTOCOL 0x00

--- a/src/tusb_edpt_handler.h
+++ b/src/tusb_edpt_handler.h
@@ -12,7 +12,7 @@
 #include "device/usbd_pvt.h"
 #include "DAP_config.h"
 
-#include "pico/usb_reset_interface_device.h"
+#include "pico/usb_reset.h"
 
 #define DAP_INTERFACE_SUBCLASS 0x00
 #define DAP_INTERFACE_PROTOCOL 0x00

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -204,7 +204,7 @@ https://developers.google.com/web/fundamentals/native-hardware/build-for-webusb/
 (Section Microsoft OS compatibility descriptors)
 */
 #define MS_OS_FEATURE_DESC_LEN 0xA0
-#define MS_OS_20_DESC_LEN  (0x0A + 0x08 + (MS_OS_FEATURE_DESC_LEN*2))
+#define MS_OS_20_DESC_LEN  (0x0A + 0x08 + MS_OS_FEATURE_DESC_LEN + RPI_RESET_MS_OS_20_DESC_LEN)
 
 #define BOS_TOTAL_LEN      (TUD_BOS_DESC_LEN + TUD_BOS_MICROSOFT_OS_DESC_LEN)
 
@@ -244,24 +244,7 @@ uint8_t const desc_ms_os_20[] =
   'A', 0x00, 'A', 0x00, '3', 0x00, '6', 0x00, '-', 0x00, '1', 0x00, 'A', 0x00, 'A', 0x00, 'E', 0x00, '4', 0x00,
   '6', 0x00, '4', 0x00, '6', 0x00, '3', 0x00, '7', 0x00, '7', 0x00, '6', 0x00, '}', 0x00, 0x00, 0x00, 0x00, 0x00,
 
-  // Function Subset header: length, type, first interface, reserved, subset length
-  U16_TO_U8S_LE(0x0008), U16_TO_U8S_LE(MS_OS_20_SUBSET_HEADER_FUNCTION), ITF_NUM_RESET, 0, U16_TO_U8S_LE(MS_OS_FEATURE_DESC_LEN),
-
-  // MS OS 2.0 Compatible ID descriptor: length, type, compatible ID, sub compatible ID
-  U16_TO_U8S_LE(0x0014), U16_TO_U8S_LE(MS_OS_20_FEATURE_COMPATBLE_ID), 'W', 'I', 'N', 'U', 'S', 'B', 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // sub-compatible
-
-  // MS OS 2.0 Registry property descriptor: length, type
-  U16_TO_U8S_LE(MS_OS_FEATURE_DESC_LEN-0x08-0x14), U16_TO_U8S_LE(MS_OS_20_FEATURE_REG_PROPERTY),
-  U16_TO_U8S_LE(0x0007), U16_TO_U8S_LE(0x002A), // wPropertyDataType, wPropertyNameLength and PropertyName "DeviceInterfaceGUIDs\0" in UTF-16
-  'D', 0x00, 'e', 0x00, 'v', 0x00, 'i', 0x00, 'c', 0x00, 'e', 0x00, 'I', 0x00, 'n', 0x00, 't', 0x00, 'e', 0x00,
-  'r', 0x00, 'f', 0x00, 'a', 0x00, 'c', 0x00, 'e', 0x00, 'G', 0x00, 'U', 0x00, 'I', 0x00, 'D', 0x00, 's', 0x00, 0x00, 0x00,
-  U16_TO_U8S_LE(0x0050), // wPropertyDataLength
-  // bPropertyData "{BDB3B5AD-293B-4663-AA36-1AAE46463776}" as a UTF-16 string (b doesn't mean bytes)
-  '{', 0x00, 'B', 0x00, 'D', 0x00, 'B', 0x00, '3', 0x00, 'B', 0x00, '5', 0x00, 'A', 0x00, 'D', 0x00, '-', 0x00,
-  '2', 0x00, '9', 0x00, '3', 0x00, 'B', 0x00, '-', 0x00, '4', 0x00, '6', 0x00, '6', 0x00, '3', 0x00, '-', 0x00,
-  'A', 0x00, 'A', 0x00, '3', 0x00, '6', 0x00, '-', 0x00, '1', 0x00, 'A', 0x00, 'A', 0x00, 'E', 0x00, '4', 0x00,
-  '6', 0x00, '4', 0x00, '6', 0x00, '3', 0x00, '7', 0x00, '7', 0x00, '6', 0x00, '}', 0x00, 0x00, 0x00, 0x00, 0x00,
+  RPI_RESET_MS_OS_20_DESCRIPTOR(ITF_NUM_RESET)
 };
 
 TU_VERIFY_STATIC(sizeof(desc_ms_os_20) == MS_OS_20_DESC_LEN, "Incorrect size");

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -28,7 +28,7 @@
 #include "tusb.h"
 #include "get_serial.h"
 #include "probe_config.h"
-#include "pico/usb_reset_interface.h"
+#include "pico/usb_reset_interface_device.h"
 
 //--------------------------------------------------------------------+
 // Device Descriptors

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -28,7 +28,7 @@
 #include "tusb.h"
 #include "get_serial.h"
 #include "probe_config.h"
-#include "pico/usb_reset_interface_device.h"
+#include "pico/usb_reset.h"
 
 //--------------------------------------------------------------------+
 // Device Descriptors


### PR DESCRIPTION
This depends on https://github.com/raspberrypi/pico-sdk/pull/2629

This adds a reset interface, to allow resetting the debugprobe to BOOTSEL mode without unplugging by running `picotool reboot -u -f --pid 0xc`

Supercedes #108