### PR TITLE
autobaud: Fix baud_changed undefined reference (#190)

### DIFF
--- a/src/autobaud.c
+++ b/src/autobaud.c
@@ -194,7 +194,7 @@ bool dma_configure(PIO pio, uint sm) {
 
 // Compare rounded integer parts of baud rates
 // Tolerance of 0.5% in detected versus set
-inline bool baud_changed(float new_baud, float baud) {
+static inline bool baud_changed(float new_baud, float baud) {
     uint32_t hi = (uint32_t)(baud * 1.005f);
     uint32_t lo = (uint32_t)(baud * 0.995f);
     uint32_t new = (uint32_t)new_baud;


### PR DESCRIPTION
Fixes a linker error that occurs when building with -DCMAKE_BUILD_TYPE=MinSizeRel.
In this configuration build fails with an undefined reference to baud_changed in autobaud.c.

Toolchain: 
arm-none-eabi-gcc

Observed error: 
debugprobe/src/autobaud.c:246: undefined reference to `baud_changed'
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/debugprobe.dir/build.make:1768: debugprobe.elf] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:1844: CMakeFiles/debugprobe.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2

Fix:
Mark the inline function as static to avoid the baud_changed symbol being omitted in optimised builds.