### PR TITLE
Add PIO GPIO base selection addressing GPIO 32 and above

### DIFF
--- a/include/board_example_config.h
+++ b/include/board_example_config.h
@@ -45,6 +45,8 @@
 #define PROBE_PIN_RESET 1
 
 #define PROBE_SM 0
+/* Set PROBE_PIO_BASE base to 16 to use gpio 32 and above */
+#define PROBE_PIO_BASE 0
 #define PROBE_PIN_OFFSET 12
 /* PIO config for PROBE_IO_RAW */
 #if defined(PROBE_IO_RAW)

--- a/src/probe.c
+++ b/src/probe.c
@@ -150,6 +150,9 @@ void probe_write_mode(void) {
 
 void probe_init() {
     if (!probe.initted) {
+        // MUST be early, before any SM config/init that uses pins
+        pio_set_gpio_base(pio0,PROBE_PIO_BASE);
+
         probe_gpio_init();
         uint offset = pio_add_program(pio0, &probe_program);
         probe.offset = offset;

--- a/src/probe.pio
+++ b/src/probe.pio
@@ -102,15 +102,15 @@ static inline void probe_gpio_deinit()
 static inline void probe_sm_init(pio_sm_config* sm_config) {
 
     // Set SWCLK as a sideset pin
-    sm_config_set_sideset_pins(sm_config, PROBE_PIN_SWCLK);
+    sm_config_set_sideset_pins(sm_config, PIO_PIN(PROBE_PIN_SWCLK));
 
     // Set SWDIO offset
-    sm_config_set_out_pins(sm_config, PROBE_PIN_SWDIO, 1);
-    sm_config_set_set_pins(sm_config, PROBE_PIN_SWDIO, 1);
+    sm_config_set_out_pins(sm_config, PIO_PIN(PROBE_PIN_SWDIO), 1);
+    sm_config_set_set_pins(sm_config, PIO_PIN(PROBE_PIN_SWDIO), 1);
 #ifdef PROBE_IO_SWDI
-    sm_config_set_in_pins(sm_config, PROBE_PIN_SWDI);
+    sm_config_set_in_pins(sm_config, PIO_PIN(PROBE_PIN_SWDI));
 #else
-    sm_config_set_in_pins(sm_config, PROBE_PIN_SWDIO);
+    sm_config_set_in_pins(sm_config, PIO_PIN(PROBE_PIN_SWDIO));
 #endif
 
 

--- a/src/probe_config.h
+++ b/src/probe_config.h
@@ -71,6 +71,11 @@ do { \
 #include "board_debug_probe_config.h"
 #endif
 //#include "board_example_config.h"
+#if !defined(PROBE_PIO_BASE)
+#define PROBE_PIO_BASE 0
+#endif
+#define PIO_PIN(gpio) ((gpio) - PROBE_PIO_BASE)
+
 
 // Add the configuration to binary information
 void bi_decl_config();

--- a/src/probe_oen.pio
+++ b/src/probe_oen.pio
@@ -81,12 +81,13 @@ static inline void probe_gpio_deinit()
 static inline void probe_sm_init(pio_sm_config* sm_config) {
 
     // Set SWDIOEN and SWCLK as sideset pins
-    sm_config_set_sideset_pins(sm_config, PROBE_PIN_SWDIOEN);
+    sm_config_set_sideset_pins(sm_config, PIO_PIN(PROBE_PIN_SWDIOEN));
 
     // Set SWDIO offset
-    sm_config_set_out_pins(sm_config, PROBE_PIN_SWDIO, 1);
-    sm_config_set_set_pins(sm_config, PROBE_PIN_SWDIO, 1);
-    sm_config_set_in_pins(sm_config, PROBE_PIN_SWDI);
+    sm_config_set_out_pins(sm_config, PIO_PIN(PROBE_PIN_SWDIO), 1);
+    sm_config_set_set_pins(sm_config, PIO_PIN(PROBE_PIN_SWDIO), 1);
+    
+    sm_config_set_in_pins(sm_config, PIO_PIN(PROBE_PIN_SWDI));
 
     // Set SWDIOEN, SWD and SWDIO pins as output to start. This will be set in the sm
     pio_sm_set_consecutive_pindirs(pio0, PROBE_SM, PROBE_PIN_OFFSET, 3, true);


### PR DESCRIPTION
When using boards that have SWD pins on 32 or above you need to set the pio gpio base and offset pin numbers for the pio pins accordingly. 

This is tested(probe.pio at least) and working with TBD hardware with pico 2350 programming an STM32 over SWD on pins 46 and 47.