### PR TITLE
Add DEBUG_PROBE_BOARD setting in config and include board config header based on that

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ target_compile_definitions (debugprobe PRIVATE
 	PICO_RP2040_USB_DEVICE_ENUMERATION_FIX=1
 )
 
+set(DEBUG_PROBE_BOARD "debug_probe" CACHE STRING "Debug Probe board to build for")
+
 option (DEBUG_ON_PICO "Compile firmware for the Pico instead of Debug Probe" OFF)
 if (DEBUG_ON_PICO)
     target_compile_definitions (debugprobe PRIVATE
@@ -79,6 +81,10 @@ if (DEBUG_ON_PICO)
     else ()
         message(SEND_ERROR "Unsupported board ${PICO_BOARD}")
     endif ()
+else ()
+    target_compile_definitions(debugprobe PRIVATE
+        BOARD_CONFIG_HEADER=\"board_${DEBUG_PROBE_BOARD}_config.h\"
+    )
 endif ()
 
 

--- a/src/probe_config.h
+++ b/src/probe_config.h
@@ -68,7 +68,7 @@ do { \
 #ifdef DEBUG_ON_PICO 
 #include "board_pico_config.h"
 #else
-#include "board_debug_probe_config.h"
+#include BOARD_CONFIG_HEADER
 #endif
 //#include "board_example_config.h"
 


### PR DESCRIPTION
Making it possible to add custom boards that are not in PICO_SDK by having the board config #include use a #define built in cmake. For example setting DEBUG_PROBE_BOARD to (the default)  "debug_probe" would include "board_debug_probe_config.h" whereas setting it to "example" includes "board_example_config.h" instead.