### PR TITLE
Correct handling of threads in suspend-disconnect cycles

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -106,6 +106,8 @@ void tud_event_hook_cb(uint8_t rhport, uint32_t eventid, bool in_isr)
   }
 }
 
+void tud_unmount_cb(void);
+
 void usb_thread(void *ptr)
 {
   uint32_t cmd;
@@ -123,7 +125,11 @@ void usb_thread(void *ptr)
         else
             gpio_put(PROBE_USB_CONNECTED_LED, 0);
 #endif
-        // If suspended or disconnected, delay for 1ms (20 ticks)
+        // implied bus-reset detection
+        if (!tud_connected() && was_configured)
+            tud_unmount_cb();
+
+        // If suspended or disconnected, unconditional delay for 1ms (20 ticks)
         if (tud_suspended() || !tud_connected())
             xTaskDelayUntil(&wake, 20);
         // Go to sleep if nothing to do
@@ -264,15 +270,15 @@ void tud_resume_cb(void)
 {
   probe_info("Resumed\n");
   if (was_configured) {
-	  vTaskResume(uart_taskhandle);
-	  vTaskResume(dap_taskhandle);
+    vTaskResume(uart_taskhandle);
+    vTaskResume(dap_taskhandle);
     vTaskResume(autobaud_taskhandle);
   }
 }
 
 void tud_unmount_cb(void)
 {
-  probe_info("Disconnected\n");
+  probe_info("Disconnected/reset\n");
   vTaskSuspend(uart_taskhandle);
   vTaskSuspend(dap_taskhandle);
   vTaskDelete(uart_taskhandle);
@@ -286,7 +292,7 @@ void tud_unmount_cb(void)
 
 void tud_mount_cb(void)
 {
-  probe_info("Connected, Configured\n");
+  probe_info("Connected, Configured: %d\n", !!was_configured);
   if (!was_configured) {
     /* UART needs to preempt USB as if we don't, characters get lost */
     xTaskCreate(cdc_thread, "UART", configMINIMAL_STACK_SIZE, NULL, UART_TASK_PRIO, &uart_taskhandle);

--- a/src/tusb_edpt_handler.c
+++ b/src/tusb_edpt_handler.c
@@ -37,21 +37,40 @@ bool buffer_empty(buffer_t *buffer)
 	return (buffer->wptr == buffer->rptr);
 }
 
+// Defer setup to .reset() / .open()
 void dap_edpt_init(void) {
 	edpt_spoon = xSemaphoreCreateMutex();
 	xSemaphoreGive(edpt_spoon);
 }
 
+// This only gets called if the SOF watchdog times out
 bool dap_edpt_deinit(void)
 {
-	memset(&USBRequestBuffer, 0, sizeof(USBRequestBuffer));
-	memset(&USBResponseBuffer, 0, sizeof(USBResponseBuffer));
-	vSemaphoreDelete(edpt_spoon);
+	if (edpt_spoon != NULL)
+		vSemaphoreDelete(edpt_spoon);
+	edpt_spoon = NULL;
 	return true;
 }
 
 void dap_edpt_reset(uint8_t __unused rhport)
 {
+	probe_info("dap_edpt_reset\n");
+	memset(&USBRequestBuffer, 0, sizeof(USBRequestBuffer));
+	memset(&USBResponseBuffer, 0, sizeof(USBResponseBuffer));
+
+	//  Initialise circular buffer indices
+	USBResponseBuffer.wptr = 0;
+	USBResponseBuffer.rptr = 0;
+	USBRequestBuffer.wptr = 0;
+	USBRequestBuffer.rptr = 0;
+
+	// Initialse full/empty flags
+	USBResponseBuffer.wasFull = false;
+	USBResponseBuffer.wasEmpty = true;
+	USBRequestBuffer.wasFull = false;
+	USBRequestBuffer.wasEmpty = true;
+	// Linux resets us twice in succession
+
 	itf_num = 0;
 }
 
@@ -89,22 +108,10 @@ char * dap_cmd_string[] = {
 
 uint16_t dap_edpt_open(uint8_t __unused rhport, tusb_desc_interface_t const *itf_desc, uint16_t max_len)
 {
-
+	// This has an *implicit return* if fails. .open() is called for each interface on the device on usb SET_CONFIGURATION(nr)
 	TU_VERIFY(TUSB_CLASS_VENDOR_SPECIFIC == itf_desc->bInterfaceClass &&
 			DAP_INTERFACE_SUBCLASS == itf_desc->bInterfaceSubClass &&
 			DAP_INTERFACE_PROTOCOL == itf_desc->bInterfaceProtocol, 0);
-
-	//  Initialise circular buffer indices
-	USBResponseBuffer.wptr = 0;
-	USBResponseBuffer.rptr = 0;
-	USBRequestBuffer.wptr = 0;
-	USBRequestBuffer.rptr = 0;
-
-	// Initialse full/empty flags
-	USBResponseBuffer.wasFull = false;
-	USBResponseBuffer.wasEmpty = true;
-	USBRequestBuffer.wasFull = false;
-	USBRequestBuffer.wasEmpty = true;
 
 	uint16_t const drv_len = sizeof(tusb_desc_interface_t) + (itf_desc->bNumEndpoints * sizeof(tusb_desc_endpoint_t));
 	TU_VERIFY(max_len >= drv_len, 0);
@@ -227,7 +234,7 @@ void dap_thread(void *ptr)
 			// Read a single packet from the USB buffer into the DAP Request buffer
 			probe_info("%lu %lu DAP cmd %s len %02x\n",
 					   USBRequestBuffer.wptr, USBRequestBuffer.rptr,
-					   dap_cmd_string[RD_SLOT_PTR(USBRequestBuffer)[0], RD_SLOT_PTR(USBRequestBuffer)[1]]);
+					   dap_cmd_string[*RD_SLOT_PTR(USBRequestBuffer)], *(RD_SLOT_PTR(USBRequestBuffer)+1));
 
 			// If the buffer was full in the out callback, we need to queue up another buffer for the endpoint to consume, now that we know there is space in the buffer.
 			xSemaphoreTake(edpt_spoon, portMAX_DELAY); // Suspend the scheduler to safely update the write index
@@ -243,7 +250,7 @@ void dap_thread(void *ptr)
 			USBRequestBuffer.rptr++;
 			probe_info("%lu %lu DAP resp %s len %u\n",
 					   USBResponseBuffer.wptr, USBResponseBuffer.rptr,
-					   dap_cmd_string[WR_SLOT_PTR(USBResponseBuffer)[0], resp_len);
+					   dap_cmd_string[*WR_SLOT_PTR(USBResponseBuffer)], resp_len);
 
 			USBResponseBuffer.data_len[WR_IDX(USBResponseBuffer)] = resp_len;
 			//  Suspend the scheduler to avoid stale values/race conditions between threads


### PR DESCRIPTION
A suspend followed by bus reset or disconnect event would leave interface threads suspended. CDC-ACM was reactivated by the unconditional pause/resume when changing baudrate, which happens automaticaly on host interface driver bind on both Windows and Linux.

DAP was not so lucky as it was changed to use semaphores instead of suspend/resume.

TinyUSB doesn't have a callback for "bus reset", it has to be implied from tud_connected(). Explicitly delete threads on an implied reset, then respawn on a SET_CONFIGURATION event.

Fixes https://github.com/raspberrypi/debugprobe/issues/201