### PR TITLE
Move board selection logic into a dedicated header

### DIFF
--- a/include/board_config.h
+++ b/include/board_config.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+ * Copyright (c) 2023 Raspberry Pi (Trading) Ltd.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,57 +23,16 @@
  *
  */
 
-#ifndef PROBE_CONFIG_H_
-#define PROBE_CONFIG_H_
+#ifndef BOARD_CONFIG_H_
+#define BOARD_CONFIG_H_
 
-#include "FreeRTOS.h"
-#include "task.h"
+// TODO tie this up with PICO_BOARD defines in the main SDK
 
-#if false
-#define probe_info(format,args...) \
-do { \
-	vTaskSuspendAll(); \
-	printf(format, ## args); \
-	xTaskResumeAll(); \
-} while (0)
+#ifdef DEBUG_ON_PICO
+#include "board_pico_config.h"
 #else
-#define probe_info(format,...) ((void)0)
+#include "board_debug_probe_config.h"
 #endif
-
-
-#if false
-#define probe_debug(format,args...) \
-do { \
-	vTaskSuspendAll(); \
-	printf(format, ## args); \
-	xTaskResumeAll(); \
-} while (0)
-#else
-#define probe_debug(format,...) ((void)0)
-#endif
-
-#if false
-#define probe_dump(format,args...)\
-do { \
-	vTaskSuspendAll(); \
-	printf(format, ## args); \
-	xTaskResumeAll(); \
-} while (0)
-#else
-#define probe_dump(format,...) ((void)0)
-#endif
-
-#include "board_config.h"
-
-// Add the configuration to binary information
-void bi_decl_config();
-
-#define PROTO_DAP_V1 1
-#define PROTO_DAP_V2 2
-
-// Interface config
-#ifndef PROBE_DEBUG_PROTOCOL
-#define PROBE_DEBUG_PROTOCOL PROTO_DAP_V2
-#endif
+//#include "board_example_config.h"
 
 #endif

--- a/include/board_debug_probe_config.h
+++ b/include/board_debug_probe_config.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef BOARD_DEBUG_PROBE_H_
-#define BOARD_DEBUG_PROBE_H_
+#ifndef BOARD_DEBUG_PROBE_CONFIG_H_
+#define BOARD_DEBUG_PROBE_CONFIG_H_
 
 #define PROBE_IO_SWDI
 #define PROBE_CDC_UART

--- a/include/board_example_config.h
+++ b/include/board_example_config.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef BOARD_EXAMPLE_H_
-#define BOARD_EXAMPLE_H_
+#ifndef BOARD_EXAMPLE_CONFIG_H_
+#define BOARD_EXAMPLE_CONFIG_H_
 #error "Example board configuration requested - specify PICO_BOARD and re-run CMake."
 
 /* Select one of these. */

--- a/include/board_pico_config.h
+++ b/include/board_pico_config.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef BOARD_PICO_H_
-#define BOARD_PICO_H_
+#ifndef BOARD_PICO_CONFIG_H_
+#define BOARD_PICO_CONFIG_H_
 
 #define PROBE_IO_RAW
 #define PROBE_CDC_UART


### PR DESCRIPTION
This pulls the board selection logic out of probe_config.h and moves it to its own, dedicated header file: include/board_config.h. Isolating this logic will reduce the blast radius of any future commits to modify or add board-specific configuration details.

The include guards in the existing board configuration headers are also extended to fully match their filenames.

These changes are cosmetic only; they shouldn't change the overall build process or resulting binaries.

#210